### PR TITLE
Fixed: Set dashboard as default homepage

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,38 +1,35 @@
-import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
+import { BrowserRouter, Route, Routes } from "react-router-dom";
 import Login from "./pages/login";
 import SignUp from "./pages/signup";
 import PasswordRecovery from "./pages/passwordRecovery";
-import MapPage from "./pages/mapPage";
 import FrontEndLayout from "./layouts/FrontEndLayout";
 import Overview from "./components/Overview";
 import Settings from "./components/Settings";
-import Map from "./components/Map";
 import { ROUTES } from "./constants/routes";
 import DashboardHomePage from "./pages/DashboardHomePage";
 import CoordinatesAndLocation from "./components/CoordinatesAndLocation";
+import MapPage from "./pages/mapPage";
 
 export default function App() {
   return (
-    <Router>
-      <div className="App">
+    <BrowserRouter>
+      <main className="App">
         <Routes>
           <Route path="/login" element={<Login />} />
           <Route path="/signup" element={<SignUp />} />
           <Route path="/password-recovery" element={<PasswordRecovery />} />
-          <Route path="/" element={<Login />} />
-          <Route path="/map" element={<MapPage />} />
           <Route
             path="/co-ordinates-location"
             element={<CoordinatesAndLocation />}
           />
-          <Route path={`/${ROUTES.dashboard}`} element={<FrontEndLayout />}>
-            <Route path="" element={<DashboardHomePage />} />
-            <Route path="map" element={<Map />} />
+          <Route path={`${ROUTES.dashboard}`} element={<FrontEndLayout />}>
+            <Route path="/" element={<DashboardHomePage />} />
+            <Route path="/map" element={<MapPage />} />
             <Route path="overview" element={<Overview />} />
             <Route path="settings" element={<Settings />} />
           </Route>
         </Routes>
-      </div>
-    </Router>
+      </main>
+    </BrowserRouter>
   );
 }

--- a/frontend/src/components/HazardForm.tsx
+++ b/frontend/src/components/HazardForm.tsx
@@ -1,24 +1,110 @@
+"use client";
+
+// import React, { useState } from "react";
 import Swal from "sweetalert2";
+import { apiNewHazardReporter } from "../services/api";
+import SubmitButton from "./SubmitButton";
+// import { MapContainer, TileLayer, Marker, useMapEvents } from "react-leaflet";
+// import type { LatLngExpression, LeafletMouseEvent } from "leaflet";
+import "leaflet/dist/leaflet.css";
+import { useAuth } from "../context/AuthContext";
+import { useNavigate } from "react-router-dom";
+import { toast } from "react-toastify";
 
 type HazardFormProps = {
   onSuccess: () => void;
 };
 
-import React from "react";
-import { apiNewHazardReporter } from "../services/api";
-import SubmitButton from "./SubmitButton";
+// 🌍 Sub-component: Select location using OpenStreetMap
+// function LocationPicker({
+//   onLocationSelect,
+// }: {
+//   onLocationSelect: (address: string) => void;
+// }) {
+//   const [position, setPosition] = useState<[number, number] | null>(null);
+//   const [address, setAddress] = useState<string>("");
 
-export default function HazardForm(props: HazardFormProps) {
+//   function LocationMarker() {
+//     useMapEvents({
+//       click: async (e: LeafletMouseEvent) => {
+//         const { lat, lng } = e.latlng;
+//         setPosition([lat, lng]);
+
+//         try {
+//           // Reverse geocode with Nominatim API
+//           const response = await fetch(
+//             `https://nominatim.openstreetmap.org/reverse?lat=${lat}&lon=${lng}&format=json`,
+//             {
+//               headers: {
+//                 "Accept-Language": "en",
+//                 "User-Agent": "hazard-reporter-app/1.0 (contact@example.com)",
+//               },
+//             }
+//           );
+//           const data = await response.json();
+//           const newAddress = data.display_name || "Unknown location";
+
+//           setAddress(newAddress);
+//           onLocationSelect(newAddress);
+//         } catch (err) {
+//           console.error("Reverse geocoding failed:", err);
+//           setAddress("Unknown location");
+//           onLocationSelect("Unknown location");
+//         }
+//       },
+//     });
+
+//     return position ? <Marker position={position as LatLngExpression} /> : null;
+//   }
+
+//   const center: LatLngExpression = [5.6037, -0.187]; // Accra
+
+//   return (
+//     <div className="flex flex-col gap-2">
+//       <div className="h-64 w-full rounded-lg overflow-hidden">
+//         <MapContainer center={center} zoom={13} className="h-full w-full z-0">
+//           <TileLayer
+//             attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+//             url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+//           />
+//           <LocationMarker />
+//         </MapContainer>
+//       </div>
+
+//       {address && (
+//         <p className="text-sm text-gray-700 mt-1">
+//           📍 <span className="font-medium">Selected:</span> {address}
+//         </p>
+//       )}
+//     </div>
+//   );
+// }
+
+// 🌿 Main Hazard Form
+export default function HazardForm({ onSuccess }: HazardFormProps) {
+  // const [location, setLocation] = useState<string>("");
+  const navigate = useNavigate();
+
+  const { isLoggedIn } = useAuth();
+  if (!isLoggedIn) {
+    toast.success("Kindly Login to report hazard", {
+      position: "top-right",
+      autoClose: 1500,
+    });
+    setTimeout(() => navigate("/login"), 1500);
+    return null;
+  }
+
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
     try {
       const form = event.target as HTMLFormElement;
       const formData = new FormData(form);
+      // formData.append("location", location);
 
       await apiNewHazardReporter(formData);
-
-      props.onSuccess();
+      onSuccess();
 
       Swal.fire({
         icon: "success",
@@ -43,8 +129,8 @@ export default function HazardForm(props: HazardFormProps) {
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
             <div>
               <label
-                className="block text-sm font-medium text-gray-700"
                 htmlFor="title"
+                className="block text-sm font-medium text-gray-700"
               >
                 Title
               </label>
@@ -53,15 +139,15 @@ export default function HazardForm(props: HazardFormProps) {
                 id="title"
                 name="title"
                 className="w-full mt-1 px-3 py-2 border border-gray-300 rounded-md shadow-sm 
-            focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
+                focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
                 required
               />
             </div>
 
             <div>
               <label
-                className="block text-sm font-medium text-gray-700"
                 htmlFor="hazardtype"
+                className="block text-sm font-medium text-gray-700"
               >
                 Select Hazard Type
               </label>
@@ -69,11 +155,10 @@ export default function HazardForm(props: HazardFormProps) {
                 id="hazardtype"
                 name="hazardtype"
                 className="mt-1 block w-full px-3 py-2 border text-gray-700 border-gray-300 rounded-md shadow-sm 
-            focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
+                focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
+                required
               >
-                <option value="" disabled className="text-[#B3B3B3]">
-                  select from list
-                </option>
+                <option value="">Select from list</option>
                 <option value="environmental">Environmental</option>
                 <option value="noise">Noise</option>
                 <option value="accident">Accident</option>
@@ -87,8 +172,8 @@ export default function HazardForm(props: HazardFormProps) {
             {/* Description */}
             <div className="flex-1">
               <label
-                className="block text-sm font-medium text-gray-700"
                 htmlFor="description"
+                className="block text-sm font-medium text-gray-700"
               >
                 Description
               </label>
@@ -97,8 +182,8 @@ export default function HazardForm(props: HazardFormProps) {
                 name="description"
                 placeholder="Describe the hazard here"
                 className="mt-1 block w-full h-40 sm:h-44 md:h-52
-              px-6 py-4 border border-gray-300 rounded-md shadow-sm 
-            focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
+                px-6 py-4 border border-gray-300 rounded-md shadow-sm 
+                focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
                 rows={4}
                 required
               ></textarea>
@@ -112,14 +197,13 @@ export default function HazardForm(props: HazardFormProps) {
               >
                 Upload Images
               </label>
-
               <label
                 htmlFor="images"
                 className="flex flex-col items-center justify-center 
-              w-full h-40 sm:h-44 md:h-52
-              px-6 py-4 border-2 border-dashed border-gray-300 rounded-md 
-              shadow-sm cursor-pointer hover:border-blue-500 hover:text-blue-500 
-              transition-colors duration-200"
+                w-full h-40 sm:h-44 md:h-52
+                px-6 py-4 border-2 border-dashed border-gray-300 rounded-md 
+                shadow-sm cursor-pointer hover:border-blue-500 hover:text-blue-500 
+                transition-colors duration-200"
               >
                 <span className="flex items-center justify-center w-12 h-12 rounded-full bg-gray-100 text-3xl text-gray-500">
                   +
@@ -128,7 +212,6 @@ export default function HazardForm(props: HazardFormProps) {
                   Click to upload
                 </span>
               </label>
-
               <input
                 type="file"
                 id="images"
@@ -141,12 +224,12 @@ export default function HazardForm(props: HazardFormProps) {
             </div>
           </div>
 
-          {/* Location Fields */}
+          {/* Country + City */}
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
             <div>
               <label
-                className="block text-sm font-medium text-gray-700"
                 htmlFor="country"
+                className="block text-sm font-medium text-gray-700"
               >
                 Country
               </label>
@@ -155,15 +238,15 @@ export default function HazardForm(props: HazardFormProps) {
                 id="country"
                 name="country"
                 className="mt-1 w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm 
-            focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
+                focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
                 required
               />
             </div>
 
             <div>
               <label
-                className="block text-sm font-medium text-gray-700"
                 htmlFor="city"
+                className="block text-sm font-medium text-gray-700"
               >
                 City
               </label>
@@ -172,46 +255,22 @@ export default function HazardForm(props: HazardFormProps) {
                 id="city"
                 name="city"
                 className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm 
-            focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
+                focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
                 required
               />
             </div>
           </div>
 
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-            <div>
-              <label
-                className="block text-sm font-medium text-gray-700"
-                htmlFor="longitude"
-              >
-                Longitude
-              </label>
-              <input
-                type="float"
-                id="longitude"
-                name="longitude"
-                className="w-full mt-1 px-3 py-2 border border-gray-300 rounded-md shadow-sm 
-            focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
-                required
-              />
-            </div>
+          {/* 🌍 Location Picker */}
+          {/* <div>
+            <label className="block text-sm font-medium text-gray-700">
+              Select Location on Map
+            </label>
+            <LocationPicker onLocationSelect={setLocation} />
+          </div> */}
 
-            <div>
-              <label
-                className="block text-sm font-medium text-gray-700"
-                htmlFor="latitude"
-              >
-                Latitude
-              </label>
-              <input
-                type="float"
-                id="latitude"
-                name="latitude"
-                className="mt-1 block w-full px-3 py-2 border text-gray-700 border-gray-300 rounded-md shadow-sm 
-            focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
-              />
-            </div>
-          </div>
+          {/* Hidden field to include location */}
+          {/* <input type="hidden" name="location" value={location} /> */}
 
           <SubmitButton />
         </form>

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -1,75 +1,110 @@
-import { Link } from "react-router-dom";
 import dashboardIcon from "../assets/images/dashboardIcon.png";
 import mapIcon from "../assets/images/mapIcon.png";
 import avatarIcon from "../assets/images/avatarIcon.png";
 import bellIcon from "../assets/images/bellIcon.png";
 import messagesIcon from "../assets/images/messagesIcon.png";
 import { ROUTES } from "../constants/routes";
+import { Link } from "react-router-dom";
+import { useAuth } from "../context/AuthContext";
 
-const Navbar = () => {
+const Navbar: React.FC = () => {
+  const { isLoggedIn, user } = useAuth();
+
   return (
     <div className="">
-      <nav className="md:w-[98%] flex md:flex-row justify-between items-center px-6 py-6">
+      <nav className="md:w-[98%] flex md:flex-row justify-between items-center px-4 py-4 md:p-6">
         <div className="hidden md:flex">
-            <h2 className="font-semibold text-md">Home</h2>
-          </div>
-        <div className="flex flex-1 justify-center items-center space-x-4">
-          
-          <div className="hidden md:flex space-x-2 border justify-between items-center rounded-full w-[262px] h-[36px] bg-[#F2F2F2]">
-            <Link
-              to={`/${ROUTES.dashboard}`}
-              className="flex items-center px-3 py-1 rounded-full text-gray-500 hover:text-black hover:bg-white space-x-2"
-            >
-              <img
-                src={dashboardIcon}
-                alt="Dashboard Icon"
-                className="w-[16px] h-[16px]"
-              />
-              <span>Dashboard</span>
-            </Link>
-            <Link
-              to="/map"
-              className="flex items-center px-3 py-1 rounded-full text-gray-500 hover:text-black hover:bg-white space-x-2"
-            >
-              <img src={mapIcon} alt="Map Icon" className="w-[16px] h-[16px]" />
-              <span>Map View</span>
-            </Link>
-          </div>
+          <h2 className="font-semibold text-md">Home</h2>
         </div>
-        <div className="w-[100%] flex justify-between md:w-fit md:flex md:items-center md:space-x-3">
-          {/* App Name */}
-          <div className="flex  md:hidden">
-            <h1 className="mr-auto">
-              <span className="font-bold">GH-HAZARD</span> <br />
-            </h1>
-          </div>
-
-          <div className="md:flex md:items-center md:space-x-2">
-            <img
-              src={avatarIcon}
-              alt="Profile Avatar"
-              className="w-8 h-8 rounded-full"
-            />
-            <div className="hidden md:flex md:flex-col">
-              <p className="font-semibold">Jane Doe</p>
-              <p className="text-sm text-gray-500">jane.doe@gmail.com</p>
+        {isLoggedIn ? (
+          <div className="flex justify-between items-center w-full md:w-fit md:gap-x-10">
+            <div className="flex flex-1 justify-center items-center space-x-4">
+              <div className="hidden md:flex space-x-2 border justify-between items-center rounded-full w-[262px] h-[36px] bg-[#F2F2F2]">
+                <Link
+                  to={`/${ROUTES.dashboard}`}
+                  className="flex items-center px-3 py-1 rounded-full text-gray-500 hover:text-black hover:bg-white space-x-2"
+                >
+                  <img
+                    src={dashboardIcon}
+                    alt="Dashboard Icon"
+                    className="w-[16px] h-[16px]"
+                  />
+                  <span>Dashboard</span>
+                </Link>
+                <Link
+                  to="/map"
+                  className="flex items-center px-3 py-1 rounded-full text-gray-500 hover:text-black hover:bg-white space-x-2"
+                >
+                  <img
+                    src={mapIcon}
+                    alt="Map Icon"
+                    className="w-[16px] h-[16px]"
+                  />
+                  <span>Map View</span>
+                </Link>
+              </div>
             </div>
-            <div className="hidden md:flex relative">
-              <img
-                src={bellIcon}
-                alt="bell Icon"
-                className="w-8 h-8 rounded-full"
-              />
-              <span className="absolute top-0 right-0 w-2 h-2 bg-red-500 rounded-full"></span>
+            <div className="w-full flex justify-between md:w-fit md:flex md:items-center md:space-x-3">
+              {/* App Name */}
+              <div className="flex  md:hidden">
+                <h1 className="">
+                  <span className="font-bold">GH-HAZARD</span> <br />
+                </h1>
+              </div>
+
+              <div className="md:flex md:items-center md:space-x-2">
+                <img
+                  src={avatarIcon}
+                  alt="Profile Avatar"
+                  className="w-9 h-9 rounded-full"
+                />
+                <div className="hidden md:flex md:flex-col md:leading-tight">
+                  <p className="text-sm text-gray-500">
+                    {user?.firstName ?? user?.userName ?? "User"}
+                  </p>
+                  <p className="text-sm text-gray-500">jane.doe@gmail.com</p>
+                </div>
+                <div className="hidden md:flex relative">
+                  <img
+                    src={bellIcon}
+                    alt="bell Icon"
+                    className="w-8 h-8 rounded-full"
+                  />
+                  <span className="absolute top-0 right-0 w-2 h-2 bg-red-500 rounded-full"></span>
+                </div>
+
+                <img
+                  src={messagesIcon}
+                  alt="messages Icon"
+                  className="hidden md:flex w-8 h-8 rounded-full"
+                />
+              </div>
+            </div>
+          </div>
+        ) : (
+          <div className="flex justify-between items-center md:flex  md:gap-x-10 w-full md:w-fit">
+            <div className="flex md:hidden">
+              <h1 className="mr-auto">
+                <span className="font-bold">GH-HAZARD</span> <br />
+              </h1>
             </div>
 
-            <img
-              src={messagesIcon}
-              alt="messages Icon"
-              className="hidden md:flex w-8 h-8 rounded-full"
-            />
+            <div className="flex gap-x-3">
+              <Link
+                to="/login"
+                className="px-3 py-1 border border-blue-600 text-blue-600 rounded-md hover:bg-blue-50"
+              >
+                Login
+              </Link>
+              <Link
+                to="/signup"
+                className="px-3 py-1 bg-blue-600 text-white rounded-md hover:bg-blue-700"
+              >
+                Sign Up
+              </Link>
+            </div>
           </div>
-        </div>
+        )}
       </nav>
     </div>
   );

--- a/frontend/src/components/RecentPostCard.tsx
+++ b/frontend/src/components/RecentPostCard.tsx
@@ -63,7 +63,7 @@ export default function RecentPostCard({ hazard }: RecentPostProps) {
             <FaRegCommentDots /> comment
           </span> */}
           <span className="flex items-center gap-2">
-            <CiShare2 /> shares
+            <CiShare2 /> share
           </span>
         </div>
       </div>

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -132,7 +132,7 @@ const Sidebar: React.FC = () => {
         </button>
          ) : (
           <button
-          onClick={() => navigate("/")}  
+          onClick={() => navigate("/login")}  
           className="text-gray-400 text-[10px] font-medium flex flex-col items-center hover:bg-[#E8E8EA] active:text-black"
         >
           <LogIn />

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,23 +1,33 @@
-import { Link, useLocation } from "react-router-dom";
+import { Link, useLocation, useNavigate } from "react-router-dom";
 import overviewIcon from "../assets/images/overviewIcon.png";
 import homeIcon from "../assets/images/homeIcon.png";
 import mapIcon from "../assets/images/mapIcon.png";
 import SettingsIcon from "../assets/images/settingsIcon.png";
-import LogOutIcon from "../assets/images/logOutIcon.png";
+// import LogOutIcon from "../assets/images/logOutIcon.png";
 import { ROUTES } from "../constants/routes";
+import { useAuth } from "../context/AuthContext";
+import { LogIn, LogOut } from "lucide-react";
 
 const Sidebar: React.FC = () => {
   const location = useLocation();
 
+  const { isLoggedIn, logout } = useAuth();
+  const navigate = useNavigate();
+
+  const handleLogout = () => {
+    logout();
+    navigate("/"); // dashboard is the home
+  };
+
   const navItems = [
-    { to: `/${ROUTES.dashboard}`, icon: homeIcon, label: "Home" },
-    { to: "overview", icon: overviewIcon, label: "Overview" },
-    { to: "/dashboard/map", icon: mapIcon, label: "Map" },
+    { to: `${ROUTES.dashboard}`, icon: homeIcon, label: "Home" },
+    { to: "/overview", icon: overviewIcon, label: "Overview" },
+    { to: "/map", icon: mapIcon, label: "Map" },
   ];
 
   const bottomItems = [
-    { to: "settings", icon: SettingsIcon, label: "Settings" },
-    { to: "/login", icon: LogOutIcon, label: "Logout" },
+    { to: "/settings", icon: SettingsIcon, label: "Settings" },
+    // { to: "/login", icon: LogOutIcon, label: "Logout" },
   ];
 
   return (
@@ -66,6 +76,19 @@ const Sidebar: React.FC = () => {
                 <span>{item.label}</span>
               </Link>
             ))}
+            {isLoggedIn ? (
+              <button
+                onClick={handleLogout}
+                className="text-gray-700 flex items-center h-[35px] p-2 hover:bg-[#E8E8EA] rounded-[4px] gap-[6px] w-full"
+              >
+                <LogOut className="w-[20px] h-[20px]" />
+                Logout
+              </button>
+            ) : (
+              <div className="hidden">
+                
+              </div>
+            )}
           </div>
         </nav>
       </aside>
@@ -99,6 +122,23 @@ const Sidebar: React.FC = () => {
             </Link>
           );
         })}
+        {isLoggedIn ? ( 
+        <button
+          onClick={handleLogout}
+          className="text-gray-400 text-[10px] font-medium flex flex-col items-center hover:bg-[#E8E8EA] active:text-black"
+        >
+          <LogOut />
+          Logout
+        </button>
+         ) : (
+          <button
+          onClick={() => navigate("/")}  
+          className="text-gray-400 text-[10px] font-medium flex flex-col items-center hover:bg-[#E8E8EA] active:text-black"
+        >
+          <LogIn />
+          Login
+        </button>
+         )}
       </nav>
     </>
   );

--- a/frontend/src/constants/routes.ts
+++ b/frontend/src/constants/routes.ts
@@ -1,3 +1,3 @@
 export const ROUTES = {
-    dashboard: "dashboard",
+    dashboard: "/",
 }

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -1,0 +1,66 @@
+// src/context/AuthContext.tsx
+import React, { createContext, useContext, useEffect, useState } from "react";
+
+type User = {
+  _id?: string;
+  userName?: string;
+  firstName?: string;
+  lastName?: string;
+};
+
+type AuthContextType = {
+  isLoggedIn: boolean;
+  user: User | null;
+  setLogin: (token: string, user: User) => void;
+  logout: () => void;
+};
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [isLoggedIn, setIsLoggedIn] = useState<boolean>(false);
+  const [user, setUser] = useState<User | null>(null);
+
+  // On mount, restore auth from localStorage
+  useEffect(() => {
+    const token = localStorage.getItem("token");
+    const userJson = localStorage.getItem("user");
+    if (token && userJson) {
+      try {
+        setUser(JSON.parse(userJson));
+        setIsLoggedIn(true);
+      } catch {
+        localStorage.removeItem("user");
+        setUser(null);
+        setIsLoggedIn(false);
+      }
+    }
+  }, []);
+
+  const setLogin = (token: string, userObj: User) => {
+    // persist token + user
+    localStorage.setItem("token", token);
+    localStorage.setItem("user", JSON.stringify(userObj));
+    setUser(userObj);
+    setIsLoggedIn(true);
+  };
+
+  const logout = () => {
+    localStorage.removeItem("token");
+    localStorage.removeItem("user");
+    setUser(null);
+    setIsLoggedIn(false);
+  };
+
+  return (
+    <AuthContext.Provider value={{ isLoggedIn, user, setLogin, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export const useAuth = () => {
+  const context = useContext(AuthContext);
+  if (!context) throw new Error("useAuth must be used within an AuthProvider");
+  return context;
+};

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,9 +2,12 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App.tsx'
 import './index.css'
+import { AuthProvider } from './context/AuthContext.tsx'
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <App />
+    <AuthProvider>
+        <App />
+    </AuthProvider>
   </React.StrictMode>,
 )

--- a/frontend/src/pages/login.tsx
+++ b/frontend/src/pages/login.tsx
@@ -5,12 +5,13 @@ import { apiLogin } from "../services/auth";
 import { toast, ToastContainer } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 import { ROUTES } from "../constants/routes";
+import { useAuth } from "../context/AuthContext";
 
 const Login: React.FC = () => {
   const [userName, setUserName] = useState<string>("");
   const [password, setPassword] = useState<string>("");
   const [loggingIn, setLoggingIn] = useState<boolean>(false); // 👈 new state
-
+  const { setLogin } = useAuth();
   const navigate = useNavigate();
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
@@ -20,8 +21,8 @@ const Login: React.FC = () => {
     try {
       const response = await apiLogin({ userName, password });
 
-      if (response.status === 200 && response.data?.token) {
-        localStorage.setItem("token", response.data.token);
+      if (response.status === 200 && response.data?.token || response.data?.user) {
+        setLogin(response.data.token, response.data.user);
 
         toast.success("Login successful!", {
           position: "top-right",
@@ -29,7 +30,7 @@ const Login: React.FC = () => {
         });
 
         // slight delay so toast shows before redirect
-        setTimeout(() => navigate(`/${ROUTES.dashboard}`), 1000);
+        setTimeout(() => navigate(`${ROUTES.dashboard}`), 1000);
       } else {
         toast.error("Invalid credentials. Please try again.");
       }

--- a/frontend/src/pages/mapPage.tsx
+++ b/frontend/src/pages/mapPage.tsx
@@ -1,21 +1,12 @@
 
 import React from 'react';
 import Map from '../components/Map';
-import Navbar from '../components/Navbar';
-import Sidebar  from '../components/Sidebar';
 
 const MapPage: React.FC = () => {
   return (
     <div className="flex h-screen">
-      <div>
-        <Sidebar />
-      </div>
 
       <div className="flex-1 flex flex-col">
-        <div>
-          <Navbar />
-        </div>
-
         <div className="flex-1 p-6 ">
           <Map />
         </div>


### PR DESCRIPTION
This PR basically sets the dashboard as homepage. Details include:

1. Added AuthContext to determine whether or not a user has logged-in
2. Alternates Navbar if user is logged-in or not:-
i) Shows user details when logged in for both mobile and desktop screens
ii) Shows Login or Signup buttons when user hasn't logged-in for both mobile and desktop screens

3. Updated the app routing for "/" to show the dashboard
4. Again, any attempt to post a hazard when a user hasn't logged in will redirect the user to the login page